### PR TITLE
Set exported attribute in manifest for API 31

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
 
         <service
             android:name=".scheduler.gcm.GcmJobService"
+            android:exported="true"
             android:permission="com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE">
             <intent-filter>
                 <action android:name="com.google.android.gms.gcm.ACTION_TASK_READY" />
@@ -25,6 +26,7 @@
 
         <receiver
             android:name=".scheduler.alarm.AlarmReceiver"
+            android:exported="false"
             android:enabled="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
@@ -36,6 +38,7 @@
 
         <receiver
             android:name=".scheduler.alarm.AlarmReceiver$BatteryReceiver"
+            android:exported="false"
             android:enabled="false">
             <intent-filter>
                 <action android:name="android.intent.action.ACTION_POWER_CONNECTED" />
@@ -47,6 +50,7 @@
 
         <receiver
             android:name=".scheduler.alarm.AlarmReceiver$StorageReceiver"
+            android:exported="false"
             android:enabled="false">
             <intent-filter>
                 <action android:name="android.intent.action.ACTION_DEVICE_STORAGE_LOW" />
@@ -58,13 +62,15 @@
 
         <receiver
             android:name=".scheduler.alarm.AlarmReceiver$ConnectivityReceiver"
+            android:exported="false"
             android:enabled="false">
             <intent-filter>
                 <action android:name="android.net.conn.CONNECTIVITY_CHANGE" />
             </intent-filter>
         </receiver>
 
-        <receiver android:name=".job.JobGcReceiver">
+        <receiver android:name=".job.JobGcReceiver"
+            android:exported="false">
             <!-- Run before other boot receivers to ensure the job list is sane. -->
             <intent-filter android:priority="999">
                 <action android:name="android.intent.action.BOOT_COMPLETED" />


### PR DESCRIPTION
As part of [Android 12 support DO](https://paper.dropbox.com/doc/TD-Android-12-Material-You-Spec-BPqAUhb7HnI58zVFyuKayKHdAg-cUFErtKcs2wpoqXlfq0ny#:uid=483977319507742549840855&h2=Material-You), we need to explicitly specify the exported attribute for all activities, services, receivers that have an intent filter in the manifest. Most of these are already not enabled.

- `com.google.android.gms.gcm.ACTION_TASK_READY` needs to be exported since it's not sent by the system. 
- `android.intent.action.BOOT_COMPLETED` doesn't need to be exported since only the system sends this intent.
- `android.intent.action.ACTION_DEVICE_STORAGE_LOW`, same as `BOOT_COMPLETED`
- `android.net.conn.CONNECTIVITY_CHANGE`, same as `BOOT_COMPLETED`
- `android.intent.action.ACTION_POWER_CONNECTED`, same as `BOOT_COMPLETED` but actually this one probably wouldn't even get called if it were enabled because of [Android O's broadcast ban](https://commonsware.com/blog/2017/04/11/android-o-implicit-broadcast-ban.html). 
