### PR TITLE
build: set better timeout

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,7 @@ jobs:
     name: Analyse
     runs-on: ubuntu-latest
 
+    timeout-minutes: 60
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2


### PR DESCRIPTION
Set missing timeouts to 60 to avoid using the default of 6 hours.

See https://github.com/Doist/Issues/issues/5259